### PR TITLE
Fix preview path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,4 +3,6 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
+  // Use relative paths so the app works when served from a subfolder
+  base: './',
 })


### PR DESCRIPTION
## Summary
- fix vite config base path so preview works when served from a subfolder

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688935c7cb0083259e3ab88c33522caf